### PR TITLE
fix: emit new event specifically when all data has been written to disk

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -236,7 +236,7 @@ describe('MongoLogManager', () => {
     expect(writer.logFilePath as string).to.match(/\.gz$/);
     writer.info('component', mongoLogId(12345), 'context', 'message', { foo: 'bar' });
     writer.end();
-    await once(writer, 'finish');
+    await once(writer, 'log-finish');
 
     const log = (await promisify(gunzip)(await fs.readFile(writer.logFilePath as string)))
       .toString()


### PR DESCRIPTION
The `finish` event on the target Writable itself would not indicate
this when gzip compression is being used, because the gzip stream
could finish before the subsequent `fs.write` call to the actual
target file was completed. This could truncate the file in cases
where the application quits immediately after the 'finish' event
was emitted.